### PR TITLE
Buildfix - missing implementation of other methods in LocationListener.

### DIFF
--- a/car_app_library/navigation/src/main/java/androidx/car/app/samples/navigation/car/NavigationSession.java
+++ b/car_app_library/navigation/src/main/java/androidx/car/app/samples/navigation/car/NavigationSession.java
@@ -28,6 +28,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.IBinder;
 import android.util.Log;
 
@@ -111,6 +112,21 @@ class NavigationSession extends Session implements NavigationScreen.Listener {
                 @Override
                 public void onLocationChanged(Location location) {
                     mNavigationCarSurface.updateLocationString(getLocationString(location));
+                }
+
+                @Override
+                public void onStatusChanged(String provider, int status, Bundle extras) {
+                    Log.i(TAG, "In onStatusChanged(" + provider + "," + extras + ")");
+                }
+
+                @Override
+                public void onProviderEnabled(String provider) {
+                    Log.i(TAG, "In onProviderEnabled(" + provider + ")");
+                }
+
+                @Override
+                public void onProviderDisabled(String provider) {
+                    Log.i(TAG, "In onProviderDisabled(" + provider + ")");
                 }
             };
 


### PR DESCRIPTION
As per the commit message - both compileSdkVersion and targetSdkVersion aims at API 29, not 30. In 29, onProviderDisabled(String provider), onProviderEnabled(String provider) and onStatusChanged(String provider, int status, Bundle extras) are non-default and needs to be implemented explicitly.

ref. https://github.com/android/car-samples/issues/8