### PR TITLE
Update or add dependencies to be able to build the apps and run tests

### DIFF
--- a/car_app_library/build.gradle
+++ b/car_app_library/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.0-alpha10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/car_app_library/helloworld/common/build.gradle
+++ b/car_app_library/helloworld/common/build.gradle
@@ -45,6 +45,11 @@ android {
 
 dependencies {
     implementation "androidx.car.app:app:1.3.0-alpha01"
+    implementation 'androidx.test:core:1.4.0'
+    testImplementation "androidx.car.app:app-testing:1.3.0-alpha01"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.robolectric:robolectric:4.8.2"
+    testImplementation "com.google.truth:truth:1.1.3"
 }
 
 

--- a/car_app_library/helloworld/common/build.gradle
+++ b/car_app_library/helloworld/common/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.car.app:app:1.2.0-rc01"
+    implementation "androidx.car.app:app:1.3.0-alpha01"
 }
 
 

--- a/car_app_library/navigation/common/build.gradle
+++ b/car_app_library/navigation/common/build.gradle
@@ -36,6 +36,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.core:core:1.5.0-alpha01"
 
-    implementation "androidx.car.app:app:1.2.0-rc01"
+    implementation "androidx.car.app:app:1.3.0-alpha01"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
 }

--- a/car_app_library/places/common/build.gradle
+++ b/car_app_library/places/common/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.car.app:app:1.2.0-rc01"
+    implementation "androidx.car.app:app:1.3.0-alpha01"
     implementation "androidx.core:core:1.5.0-alpha01"
     implementation 'com.google.guava:guava:28.1-jre'
 }

--- a/car_app_library/showcase/common/build.gradle
+++ b/car_app_library/showcase/common/build.gradle
@@ -35,6 +35,6 @@ android {
 
 dependencies {
     implementation "androidx.core:core:1.6.0-alpha01"
-    implementation "androidx.car.app:app:1.2.0-rc01"
+    implementation "androidx.car.app:app:1.3.0-alpha01"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
 }


### PR DESCRIPTION
If you pull the project from last [commit](https://github.com/android/car-samples/commit/12e4ef5bc1f69c30a56ab8459586cfa20b88b055), then car app library apps won't build and launch. 
These changes have to be done to successfully build and launch these apps:

1. I see that gradle version in that commit is [`4.0.1`](https://github.com/android/car-samples/blob/main/car_app_library/build.gradle#L25). It would be not possible to build the project with short names like `compileSdk 32` because this is not available in gradle version `4.0.1`. So I updated this version to latest `7.4.0-alpha10`
2. I see that last commit still uses car app library version `1.2.0-rc01`, but in this version there is no support for SessionInfo that has been used [here](https://github.com/android/car-samples/blob/main/car_app_library/helloworld/common/src/main/java/androidx/car/app/sample/helloworld/common/HelloWorldService.java#L44). So I updated it to the car app library version `1.3.0-alpha01`.
3. Last point is `helloworld tests`. There are no dependencies included for [these](https://github.com/android/car-samples/blob/main/car_app_library/helloworld/common/src/test/java/androidx/car/app/sample/helloworld/common/HelloWorldScreenTest.java) tests. So I added dependencies such as `truth`, `roboelectric` etc. to be able to run these tests.